### PR TITLE
Fix sound manager when not supported

### DIFF
--- a/sound_manager.js
+++ b/sound_manager.js
@@ -5,6 +5,16 @@ var SoundManager = (function() {
       this._context = new webkitAudioContext();
     } catch (e) {
       alert('Web Audio API is not supported in this browser');
+
+      this.loadAsync = function(path, _) {
+        return new Sound(path)
+      }
+      var noop = function() {}
+      this.togglemute = noop
+      this.stopAll = noop
+      this.playSound = noop
+
+      return
     }
 
     this._mainNode = this._context.createGain(0);


### PR DESCRIPTION
The sound manager checked for support but then assumed support. This was
an oversight not obvious at the time when chrome supported the Webkit
Audio Context. Now that chrome has moved on it's broken the game. This
commit mocks problematic methods on the sound manager with no-ops so
that the game can be played without sound.